### PR TITLE
JS compat w/ jQuery 1.9 and render CSS resources as <link />

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ There's a frood who really knows where his towel is
 1.0b12 (unreleased)
 ^^^^^^^^^^^^^^^^^^^
 
+- Fix JS to be jQuery 1.9 compat
+- Make CSS resources render as <link />
+  [simahawk]
+
 - Add French translations.
   [sophiejazwiecki]
 

--- a/src/collective/z3cform/widgets/profiles/default/cssregistry.xml
+++ b/src/collective/z3cform/widgets/profiles/default/cssregistry.xml
@@ -4,16 +4,16 @@
      <stylesheet id="++resource++collective.z3cform.widgets/related.css"
          title="" cacheable="True" compression="safe" cookable="True"
          enabled="1" expression="" media="screen"
-         rel="stylesheet" rendering="import" authenticated="True"/>
+         rel="stylesheet" rendering="link" authenticated="True"/>
 
      <stylesheet id="++resource++collective.z3cform.widgets/token-input-facebook.css"
           title="" cacheable="True" compression="safe" cookable="True"
           enabled="1" expression="" media="screen"
-          rel="stylesheet" rendering="import" authenticated="True" />
+          rel="stylesheet" rendering="link" authenticated="True" />
 
      <stylesheet id="++resource++collective.z3cform.widgets/rte.css"
           title="" cacheable="True" compression="safe" cookable="True"
           enabled="1" expression="" media="screen"
-          rel="stylesheet" rendering="import" authenticated="True" />
+          rel="stylesheet" rendering="link" authenticated="True" />
 
 </object>

--- a/src/collective/z3cform/widgets/static/related.js
+++ b/src/collective/z3cform/widgets/static/related.js
@@ -69,7 +69,7 @@ if(jQuery) (function($){
 
 (function ($) {
    $.fn.liveDraggable = function (opts) {
-      this.live("mouseover", function() {
+      $('body').on('mouseover', $(this), function() {
          if (!$(this).data("init")) {
             $(this).data("init", true).draggable(opts);
          }
@@ -80,11 +80,11 @@ if(jQuery) (function($){
 
 $(function() {
       $("#form-widgets-relatedItems-contenttree-window").draggable();
-	  $( ".relatedWidget ul.from .navTreeItem").liveDraggable({ containment: ".relatedWidget",  scroll: false, helper: "clone"}); 
+	  $( ".relatedWidget ul.from .navTreeItem").liveDraggable({ containment: ".relatedWidget",  scroll: false, helper: "clone"});
 	  $(".relatedWidget ul.recieve").droppable({
         			activeClass: "ui-state-default",
         			hoverClass: "ui-state-hover",
-        			drop: function(event, ui) {        			  
+        			drop: function(event, ui) {
         			  var children = $(this).children();
         			  var i = 0;
         			  var exists = false;
@@ -103,15 +103,15 @@ $(function() {
         			    }
         			    clon.append("<div class='related-item-close'>X</div>");
         			    clon.appendTo( this );
-        			  }	
+        			  }
         			}
         		}).sortable();
     $(".relatedWidget ul.recieve li").append("<div class='related-item-close'>X</div>");
-    $(".relatedWidget ul.recieve li a").live("click", function(e) {
+    $('body').on('click', '.relatedWidget ul.recieve li a', function(){
       e.preventDefault();
       return false;
     });
-    $(".related-item-close").live("click", function() {
+    $('body').on('click', '.related-item-close', function(){
         $(this).parent().remove();
     });
 


### PR DESCRIPTION
As per PR title: JS fixed on jq 1.9 (`related.js` was using `live`).

Render CSS as links is better for theming inclusion and also because you don't need to wait for them to load (see http://stackoverflow.com/questions/7199364/import-vs-link).